### PR TITLE
Add pointerenter and pointerleave event to NON_BUBBLEABLE_EVENTS

### DIFF
--- a/src/teact/dom-events.ts
+++ b/src/teact/dom-events.ts
@@ -3,7 +3,7 @@ import { DEBUG } from '../config';
 type Handler = (e: Event) => void;
 type DelegationRegistry = Map<HTMLElement, Handler>;
 
-const NON_BUBBLEABLE_EVENTS = new Set(['scroll', 'mouseenter', 'mouseleave', 'load']);
+const NON_BUBBLEABLE_EVENTS = new Set(['scroll', 'mouseenter', 'mouseleave', 'pointerenter', 'pointerleave', 'load']);
 
 const documentEventCounters: Record<string, number> = {};
 const delegationRegistryByEventType: Record<string, DelegationRegistry> = {};


### PR DESCRIPTION
Currently `onPointerenter` and `onPointerLeave` event will delegated by document, but this won't work.